### PR TITLE
Replace DOS headers with SDL2 wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,4 +60,6 @@ foreach(lib tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)
     endif()
 endforeach()
 
-target_link_libraries(bam PRIVATE tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)
+find_package(SDL2 REQUIRED)
+
+target_link_libraries(bam PRIVATE SDL2::SDL2 tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)

--- a/CODE/SRC/BAM.CPP
+++ b/CODE/SRC/BAM.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 //	Copyright 1994, Tachyon, Inc.
 //
@@ -7,7 +8,6 @@
 //
 
 #include <stdio.h>
-#include <conio.h>
 #include <stdarg.h>
 #include <string.h>
 #include <ctype.h>

--- a/CODE/SRC/INSTALL.CPP
+++ b/CODE/SRC/INSTALL.CPP
@@ -1,9 +1,8 @@
+#include "../compat.h"
 // This is the stupidest program in the world.
 // -Van
 
 #include <stdio.h>
-#include <mem.h>
-#include <conio.h>
 #include <ctype.h>
 #include "dpmi.hpp"
 #include "install.h"

--- a/CODE/SRC/LASTMSG.CPP
+++ b/CODE/SRC/LASTMSG.CPP
@@ -1,8 +1,7 @@
+#include "../compat.h"
 #include <stdio.h>
-#include <conio.h>
 #include <stdarg.h>
 #include <ctype.h>
-#include <mem.h>
 #include "dpmi.hpp"
 #include "last1e.h"
 #include "last1f.h"

--- a/CODE/SRC/MAKEMIF.CPP
+++ b/CODE/SRC/MAKEMIF.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // MAKEMIF.CPP
 //
@@ -9,7 +10,6 @@
 //----[]--------------------------------------------------------------------------
 
 #include <ctype.h>
-#include <conio.h>
 
 #include "apimem.hpp"
 #include "mem.hpp"

--- a/CODE/SRC/MAPEDIT.CPP
+++ b/CODE/SRC/MAPEDIT.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // Mapedit.cpp
 //
@@ -7,13 +8,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <dos.h>
 #include <ctype.h>
-#include <mem.h>
 #include <string.h>
-#include <io.h>
-#include <conio.h>
-#include <bios.h>
 
 #include "api.hpp"
 #include "apievt.hpp"

--- a/CODE/SRC/SHOWXFLI.CPP
+++ b/CODE/SRC/SHOWXFLI.CPP
@@ -1,9 +1,8 @@
+#include "../compat.h"
 #include <stdlib.h>
-#include <conio.h>
 #include <assert.h>
 #include <stdio.h>
 #include <time.h>
-#include <mem.h>
 #include <string.h>
 
 #include "mono.hpp"

--- a/CODE/SRC/STRIPLIN.CPP
+++ b/CODE/SRC/STRIPLIN.CPP
@@ -1,6 +1,6 @@
+#include "../compat.h"
 #include <stdlib.h>
 #include <stdio.h>
-#include <dos.h>
 
 void main(int argc, char *argv[])
 {

--- a/CODE/SRC/VSWITCH.CPP
+++ b/CODE/SRC/VSWITCH.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 // VSWITCH.CPP
 // Replacement for defective SWITCH.EXE used in BAM Installer
 //	for replacing the STFS drive letter in RES_CFG.HPP at install-time.
@@ -7,7 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <mem.h>
 
 #define MAX_LINES	100
 #define MAX_LINE_LEN	256

--- a/CODE/TIGRE/DPMI.CPP
+++ b/CODE/TIGRE/DPMI.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // DPMI.CPP
 //
@@ -10,7 +11,6 @@
 //----[]-------------------------------------------------------------
 
 
-#include <dos.h>
 #include <i86.h>
 
 #include "dpmi.hpp"

--- a/CODE/TIGRE/EVENTMGR.CBK
+++ b/CODE/TIGRE/EVENTMGR.CBK
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // EVENTMGR.CPP
 //
@@ -637,7 +638,6 @@ EventMgr::EnableInterrupts()
 
 #ifdef OS_DOS
 
-#include <conio.h>
 
 int	ki_debugging = FALSE;
 uchar	ki_lastChar[2] = {0,0};

--- a/CODE/TIGRE/EVENTMGR.CPP
+++ b/CODE/TIGRE/EVENTMGR.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // EVENTMGR.CPP
 //
@@ -789,7 +790,6 @@ EventMgr::EnableInterrupts()
 
 #ifdef OS_DOS
 
-#include <conio.h>
 
 int	ki_debugging = FALSE;
 uchar	ki_lastChar[2] = {0,0};

--- a/CODE/TIGRE/MAKERES.CPP
+++ b/CODE/TIGRE/MAKERES.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // MAKERES.CPP
 //
@@ -10,7 +11,6 @@
 //----[]-------------------------------------------------------------
 
 
-#include <conio.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/CODE/TIGRE/MODEM.CPP
+++ b/CODE/TIGRE/MODEM.CPP
@@ -1,5 +1,4 @@
-#include <dos.h>
-#include <conio.h>
+#include "../compat.h"
 #include <string.h>
 
 #include "types.hpp"

--- a/CODE/TIGRE/MONO.CPP
+++ b/CODE/TIGRE/MONO.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // MONO.CPP
 //
@@ -8,7 +9,6 @@
 //----[]-------------------------------------------------------------
 
 
-#include <io.h>
 #include <stdarg.h>
 
 #include "api.hpp"

--- a/CODE/TIGRE/OS.CPP
+++ b/CODE/TIGRE/OS.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // OS.CPP
 //
@@ -23,7 +24,6 @@
 	#error	This is a DOS only module!
 #endif
 
-#include <dos.h>
 #include	<i86.h>
 #include	<malloc.h>
 

--- a/CODE/TIGRE/SAVEMGR.HPP
+++ b/CODE/TIGRE/SAVEMGR.HPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // SAVEMGR.HPP
 //
@@ -12,7 +13,6 @@
 #ifndef	savemgr_hpp
 #define	savemgr_hpp
 
-#include <dos.h>
 
 #include "tigre.hpp"
 #include "savebase.hpp"

--- a/CODE/TIGRE/SERIAL.CPP
+++ b/CODE/TIGRE/SERIAL.CPP
@@ -1,4 +1,4 @@
-#include <conio.h>
+#include "../compat.h"
 #include <string.h>
 #include <time.h>
 

--- a/CODE/TIGRE/SOUNDMGR.CPP
+++ b/CODE/TIGRE/SOUNDMGR.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // SOUNDMGR.CPP
 //
@@ -103,7 +104,6 @@
 //----[]-------------------------------------------------------------
 
 #include <ctype.h>
-#include <dos.h>
 #include	"api.hpp"
 #include "apievt.hpp"
 #include "apimem.hpp"

--- a/CODE/TIGRE/TW.H
+++ b/CODE/TIGRE/TW.H
@@ -1,3 +1,4 @@
+#include "../compat.h"
 #ifndef _TEXTWIN_DOT_H
 #define _TEXTWIN_DOT_H
 
@@ -28,7 +29,6 @@
 #include <windows.h>
 
 #if defined( GCPP_SYMANTEC )
-#include <dos.h>
 #define _fcalloc farcalloc
 #define _ffree farfree
 #endif

--- a/CODE/TIGRE/XMODDISP.CPP
+++ b/CODE/TIGRE/XMODDISP.CPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //
 // XModDisp.CPP
 //
@@ -10,7 +11,6 @@
 //----[]-------------------------------------------------------------
 
 
-#include <dos.h>
 #include <i86.h>
 
 #include "api.hpp"

--- a/CODE/TIGRE/_DEFS386.H
+++ b/CODE/TIGRE/_DEFS386.H
@@ -1,3 +1,4 @@
+#include "../compat.h"
 /*
  * _DEFS386.H       3.00A  Febuary 9, 1995
  *
@@ -49,7 +50,6 @@
 
 #include "cppcomp.h"
 #if !defined( GCPP_OS2 )
-#include <dos.h>
 #endif
 
 #if defined( GCPP_X32 )

--- a/CODE/TIGRE/_DOSISR.HPP
+++ b/CODE/TIGRE/_DOSISR.HPP
@@ -1,3 +1,4 @@
+#include "../compat.h"
 //*
 //* _DOSISR.HPP
 //*
@@ -20,7 +21,6 @@
 #ifndef _DOSISR_HPP
 #define _DOSISR_HPP
 
-#include <dos.h>
 #include "cppcomp.h"
 #include "_defs386.h"
 #include "compplib.hpp"

--- a/CODE/compat.h
+++ b/CODE/compat.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <cstdio>
+#include <cstring>
+#include <thread>
+#include <queue>
+#include <chrono>
+#include <SDL2/SDL.h>
+
+// Simple compatibility layer replacing old DOS functions
+inline std::queue<SDL_Keycode>& __compat_key_queue() {
+    static std::queue<SDL_Keycode> q;
+    return q;
+}
+
+inline int kbhit() {
+    SDL_Event e;
+    while (SDL_PollEvent(&e)) {
+        if (e.type == SDL_KEYDOWN) {
+            __compat_key_queue().push(e.key.keysym.sym);
+        }
+    }
+    return !__compat_key_queue().empty();
+}
+
+inline int getch() {
+    while (!kbhit()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    int ch = __compat_key_queue().front();
+    __compat_key_queue().pop();
+    return ch;
+}
+
+inline void delay(unsigned int ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}


### PR DESCRIPTION
## Summary
- Replace legacy DOS headers with a new `compat.h` that uses SDL2 and the C++ standard library for basic input and timing.
- Integrate SDL2 into the build and swap old includes across the codebase for the compatibility wrapper.

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "SDL2"; repository not signed when attempting apt-get).*

------
https://chatgpt.com/codex/tasks/task_e_68997e601c648323ac3249208d7e193b