### PR TITLE
Use standard main signature and return codes

### DIFF
--- a/CODE/SRC/LASTMSG.CPP
+++ b/CODE/SRC/LASTMSG.CPP
@@ -14,7 +14,7 @@ const screen_size = 4000;
 
 char screenBkp[screen_size];
 
-void main(int argc, char *argv[])
+int main(int argc, char** argv)
 {
 	DPMI dpmi;
 	char *pScreen = (char *)dpmi.RealToProtected(0xB8000000), *pSrc;
@@ -48,4 +48,5 @@ void main(int argc, char *argv[])
 	getch();
 	memcpy(pScreen, screenBkp, screen_size);
 //	memset(pScreen, 0, screen_size);
+        return 0;
 }

--- a/CODE/SRC/MAPEDIT.CPP
+++ b/CODE/SRC/MAPEDIT.CPP
@@ -70,7 +70,7 @@ int curPath;
 char curName[140];
 //BAM_Application*		pBam;
 
-void main(int argc, char *argv[])
+int main(int argc, char** argv)
 {
 	Mouse			*pMouse1;
 	GraphicsMgr	*pGraphMgr1;
@@ -85,7 +85,7 @@ void main(int argc, char *argv[])
 	{
 		printf("Format: MAPEDIT <map#> [-NOCLUST]\n");
 		printf("Ex.:		MAPEDIT 9110\n");
-		return;
+		return 1;
 	}
 
 	mapResNum = atoi(argv[1]);
@@ -93,7 +93,7 @@ void main(int argc, char *argv[])
 	if(mapResNum % 20 != 10 && mapResNum % 20 != 12 && mapResNum % 20 != 15)
 	{
 		printf("Vas Error #1: invalid map number given\n");
-		return;
+		return 1;
 	}
 	if(argc > 2)
 	{
@@ -220,6 +220,7 @@ void main(int argc, char *argv[])
 //	delete pGraphMgr;
 
 //	pMemMgr->Dump();
+        return 0;
 }
 
 void SetColors(uint32 foreCol1, uint32 foreCol2, uint32 backCol)

--- a/CODE/SRC/SHOWXFLI.CPP
+++ b/CODE/SRC/SHOWXFLI.CPP
@@ -76,7 +76,7 @@ union wpt
 	}
 };
 
-void main(int argc, char *argv[])
+int main(int argc, char** argv)
 {
 	int frameloop, chunkloop, loop1;
 	SChar *chunkdata, *pScreen;
@@ -95,12 +95,13 @@ void main(int argc, char *argv[])
 	if(argc < 2)
 	{	puts("Format: SHOWXFLI <FLIC.FLC> [/STEP]\n");
 		delete pMono;
-		return;
+		return 1;
 	}
 	flicfile = fopen(argv[1], "rb");
 	if(!flicfile)
 	{	puts("Error: unable to open "); puts(argv[1]); puts("\n");
-		return;
+		delete pMono;
+                return 1;
 	}
 
 	for(loop1 = 0; loop1 <= argc; loop1++)
@@ -186,6 +187,7 @@ void main(int argc, char *argv[])
 		"int	10h";
 	RESTORE_VIDEO_MODE();
 	delete pMono;
+        return 0;
 }
 
 void decode_delta_flc(SChar* const pData, int chsize)

--- a/CODE/SRC/STRIPLIN.CPP
+++ b/CODE/SRC/STRIPLIN.CPP
@@ -2,15 +2,20 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-void main(int argc, char *argv[])
+int main(int argc, char** argv)
 {
+        if(argc < 2)
+        {
+                printf("Usage: %s <file>\n", argv[0]);
+                return 1;
+        }
 	FILE *infile = fopen(argv[1], "r"), *outfile;
 	char	string1[255];
 
 	if(!infile)
 	{
 		printf("Error: can't open \"%s\"\n", argv[1]);
-		return;
+		return 1;
 	}
 	fgets(string1, 250, infile);	// swallow first line of GREP output ("File ...")
 	outfile = fopen("striplin.tmp", "w");
@@ -25,4 +30,5 @@ void main(int argc, char *argv[])
 	sprintf(string1, "copy striplin.tmp %s", argv[1]);
 	system(string1);
 	system("del striplin.tmp");
+        return 0;
 }


### PR DESCRIPTION
## Summary
- convert MAPEDIT, STRIPLIN, SHOWXFLI, and LASTMSG utilities to `int main(int argc, char** argv)`
- add basic argument validation and return values

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SDL2" )*


------
https://chatgpt.com/codex/tasks/task_e_68997fbda2d08323bb5b79752945ea64