### PR TITLE
Add GitHub Actions workflow for cross-platform build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: Build & Analyze
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            sudo apt-get update
+            sudo apt-get install -y cmake build-essential clang-tidy cppcheck libsdl2-dev
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew update
+            brew install cmake llvm cppcheck sdl2
+          else
+            choco install -y cmake llvm cppcheck sdl2
+          fi
+        shell: bash
+
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        shell: bash
+
+      - name: Build
+        run: cmake --build build --config Release
+        shell: bash
+
+      - name: Run clang-tidy
+        run: clang-tidy -p build $(git ls-files '*.cpp')
+        shell: bash
+
+      - name: Run cppcheck
+        run: cppcheck --enable=all --project=build/compile_commands.json
+        shell: bash
+
+      - name: Verify binary
+        run: |
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            test -f build/Release/bam.exe
+          else
+            test -f build/bam
+          fi
+        shell: bash
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bam-${{ matrix.os }}
+          path: ${{ matrix.os == 'windows-latest' && 'build/Release/bam.exe' || 'build/bam' }}


### PR DESCRIPTION
## Summary
- build project on Linux, Windows, and macOS via GitHub Actions
- run cmake build and static analysis (clang-tidy & cppcheck)
- verify generated binary and upload as artifact

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*

------
https://chatgpt.com/codex/tasks/task_e_689983c079bc832391b2f20a30c3118d