### PR TITLE
Add basic engine initialization test and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
+      - name: Configure
+        run: cmake -S . -B build
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: cd build && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.20)
 project(bam LANGUAGES CXX)
 
+enable_testing()
+
 set(GAME_SOURCES
     CODE/SRC/AI.CPP
     CODE/SRC/ASSESS.CPP
@@ -63,3 +65,5 @@ endforeach()
 find_package(SDL2 REQUIRED)
 
 target_link_libraries(bam PRIVATE SDL2::SDL2 tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)
+
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(test_init test_init.cpp)
+
+target_include_directories(test_init PRIVATE ${PROJECT_SOURCE_DIR}/CODE/SRC ${PROJECT_SOURCE_DIR}/CODE/TIGRE)
+
+target_link_libraries(test_init PRIVATE SDL2::SDL2 tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)
+
+target_compile_definitions(test_init PRIVATE TEST_ASSET_DIR="${PROJECT_SOURCE_DIR}")
+
+add_test(NAME test_init COMMAND test_init)

--- a/tests/test_init.cpp
+++ b/tests/test_init.cpp
@@ -1,0 +1,16 @@
+#include <SDL.h>
+#include <cassert>
+#include <fstream>
+#include <string>
+
+int main() {
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        return 1;
+    }
+    SDL_Quit();
+
+    std::string path = std::string(TEST_ASSET_DIR) + "/1.BNK";
+    std::ifstream file(path, std::ios::binary);
+    assert(file.good());
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add simple SDL initialization and resource loading test
- wire tests into CMake and enable CTest
- add GitHub Actions workflow running cmake build and ctest

## Testing
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y libsdl2-dev` *(fails: Unable to locate package libsdl2-dev)*
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "SDL2")*

------
https://chatgpt.com/codex/tasks/task_e_689983c140f88323959855f6d6248a78