### PR TITLE
Add OS_SDL platform support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ set(GAME_SOURCES
 add_executable(bam ${GAME_SOURCES})
 
 target_include_directories(bam PRIVATE CODE/SRC CODE/TIGRE)
+target_compile_definitions(bam PRIVATE OS_SDL)
 
 add_library(tigre STATIC
     CODE/TIGRE/sdl_modex.cpp
@@ -104,6 +105,7 @@ add_library(tigre STATIC
     CODE/TIGRE/OS_STUB.CPP
 )
 target_include_directories(tigre PUBLIC CODE/TIGRE)
+target_compile_definitions(tigre PUBLIC OS_SDL)
 find_package(SDL2)
 if(SDL2_FOUND)
     target_link_libraries(tigre PUBLIC SDL2::SDL2)

--- a/CODE/TIGRE/APIGRAPH.HPP
+++ b/CODE/TIGRE/APIGRAPH.HPP
@@ -84,7 +84,7 @@ struct	ASMCopyPixels
 
 // OS-Abstracted graphics functions
 
-#ifdef OS_DOS
+#if defined(OS_DOS)
 // In Assembly in DOS/TIGRE
 extern "C"
 {
@@ -92,7 +92,7 @@ extern "C"
 	int 	OS_GetScreenMode();
 	void	OS_SetPalette(Gun* gunsArray, uint startGun, uint endGun);
 	void	OS_GetPalette(Gun* gunsArray, uint startGun, uint endGun);
-#ifdef OS_DOS
+#if defined(OS_DOS)
 }
 #endif
 
@@ -103,14 +103,14 @@ void	OS_CopyPixelLine_C(ASMCopyPixels* acp);
 // versions of OS_CopyPixelLine()
 //
 
-#ifdef OS_DOS
+#if defined(OS_DOS)
 	extern "C"
 	{
 		// DOS has optimized version in assembly
 		void	OS_CopyPixelLine_ASM(ASMCopyPixels* acp);
 	}
 	#define	OS_CopyPixelLine	OS_CopyPixelLine_ASM
-#else
+#elif defined(OS_SDL)
 	// other platforms will use portable C version
 	#define	OS_CopyPixelLine	OS_CopyPixelLine_C
 #endif
@@ -147,7 +147,7 @@ int		ADetectVGA();
 bool		AInitVideo(uint driver, uint mode, uint& vSeg,
 							coord& vWide, coord& vHigh, uint& bankInc, uint& oldMode);
 
-#ifdef OS_DOS
+#if defined(OS_DOS)
 // In Assembly in DOS/TIGRE (modex.asm)
 extern "C"
 {
@@ -156,7 +156,7 @@ void		ABlit(uint driver, uchar* pData, coord x, coord y,
 					uint bufWidth, uint bufHeight, uint bufSpan, uint vSeg);
 void		ARBlit(uint driver, uchar* pData, coord x, coord y,
 					uint bufWidth, uint bufHeight, uint vSeg);
-#ifdef OS_DOS
+#if defined(OS_DOS)
 }
 #endif
 

--- a/CODE/TIGRE/OS.HPP
+++ b/CODE/TIGRE/OS.HPP
@@ -17,7 +17,7 @@
 #include "types.hpp"
 
 
-#ifdef OS_DOS
+#if defined(OS_DOS)
 	#ifdef __WATCOMC__
 		#define	EXT_MAX		4
 	//	#define	PATH_MAX		64	// already defined
@@ -58,10 +58,20 @@
 	#define L2R(x)	LOGICAL_2_REAL(x)
 	#define R2L(x)	REAL_2_LOGICAL(x)
 
-#endif	//OS_DOS
+#elif defined(OS_SDL)
+        #define EXT_MAX         4
+        #define PATH_MAX                64
+        #define DOS_ONLY(x)
+        #define FLUSH
+        #define LOGICAL_2_REAL(x)               (x)
+        #define REAL_2_LOGICAL(x)               (x)
+        #define L2R(x)  LOGICAL_2_REAL(x)
+        #define R2L(x)  REAL_2_LOGICAL(x)
+
+#endif       //OS_DOS
 
 
-#ifdef OS_MAC
+#if defined(OS_MAC)
 
 	#define	EXT_MAX		6
 	#define	PATH_MAX		64	// already defined

--- a/CODE/TIGRE/RESMGR.CPP
+++ b/CODE/TIGRE/RESMGR.CPP
@@ -1424,6 +1424,13 @@ ResourceMgr::CopyResName(char* szFileName, res_t type, uint num, uint idx)
 		}
 		pathLen = sprintf(szFileName, "%s%u.%s", path, num, ext);
 	#endif
+        #ifdef OS_SDL
+                if (*(path + strlen(path) - 1) != '/')
+                {
+                        strcat(path, "/");
+                }
+                pathLen = sprintf(szFileName, "%s%u.%s", path, num, ext);
+        #endif
 
 	#ifdef	OS_MAC
 		if (path[0] == '.')

--- a/CODE/TIGRE/TYPES.HPP
+++ b/CODE/TIGRE/TYPES.HPP
@@ -20,9 +20,13 @@
 
 // Define a global platform definition
 #if defined(_WINDOWS) || defined(_WINDOWS_)
-	#define	OS_WINDOWS
+        #define OS_WINDOWS
+#elif defined(__linux__) || defined(__APPLE__)
+        #if !defined(OS_SDL)
+                #define OS_SDL
+        #endif
 #else
-	#define OS_DOS
+        #define OS_DOS
 #endif
 
 // Turn off some warnings that we know are acceptable

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,5 +5,6 @@ target_include_directories(test_init PRIVATE ${PROJECT_SOURCE_DIR}/CODE/SRC ${PR
 target_link_libraries(test_init PRIVATE SDL2::SDL2 tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)
 
 target_compile_definitions(test_init PRIVATE TEST_ASSET_DIR="${PROJECT_SOURCE_DIR}")
+target_compile_definitions(test_init PRIVATE OS_SDL)
 
 add_test(NAME test_init COMMAND test_init)


### PR DESCRIPTION
## Summary
- define OS_SDL for Linux/macOS builds
- add OS_SDL compile definitions and branches across platform headers
- wire OS_SDL into build system and tests

## Testing
- `cmake -S . -B build` *(passes but warns missing SDL2)*
- `cmake --build build` *(fails: gmake[2] returned Error 1 for GRAPHMGR.CPP)*
- `ctest --test-dir build` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c234fb55c8323b164d3512ebee292