### PR TITLE
Guard legacy i86 usage for SDL builds

### DIFF
--- a/CODE/TIGRE/DPMI.CPP
+++ b/CODE/TIGRE/DPMI.CPP
@@ -1,4 +1,3 @@
-#include "../compat.h"
 //
 // DPMI.CPP
 //
@@ -10,90 +9,81 @@
 //
 //----[]-------------------------------------------------------------
 
-
+#if defined(OS_DOS)
 #include <i86.h>
-
 #include "dpmi.hpp"
 
-
 DPMI::DPMI ()
-{
-}
+{}
 
 DPMI::~DPMI ()
-{
-}
-
+{}
 
 void
 DPMI::Interrupt (REGS* r, SREGS* s)
 {
   SREGS blank;
 
-	if (!s)
-	{
-		memset (&blank, 0, sizeof (blank));
-		s = &blank;
-	}
-	int386x (DPMI_INT, r, r, s);
+        if (!s)
+        {
+                memset (&blank, 0, sizeof (blank));
+                s = &blank;
+        }
+        int386x (DPMI_INT, r, r, s);
 }
-
 
 void far*
 DPMI::AllocateDosMemoryBlock (size_t size, uint16* seg)
 {
   REGS r;
 
-	r.x.eax = 0x100;
-	r.x.ebx = size / 16 + (size & 0xf ? 1 : 0);
-	Interrupt (&r);
-	if ((r.x.cflag & CARRY_FLAG) == 0)	// Carry clear on success
-	{
-		*seg = r.w.ax;
-		return (MK_FP (r.w.dx, 0));
-	}
-	return NULL;
+        r.x.eax = 0x100;
+        r.x.ebx = size / 16 + (size & 0xf ? 1 : 0);
+        Interrupt (&r);
+        if ((r.x.cflag & CARRY_FLAG) == 0)      // Carry clear on success
+        {
+                *seg = r.w.ax;
+                return (MK_FP (r.w.dx, 0));
+        }
+        return NULL;
 }
-
 
 void
 DPMI::FreeDosMemoryBlock (uint16 selector)
 {
   REGS r;
 
-	r.x.eax = 0x101;
-	r.x.edx = selector;
-	Interrupt (&r);
+        r.x.eax = 0x101;
+        r.x.edx = selector;
+        Interrupt (&r);
 }
 
 void
 DPMI::FreeDosMemoryBlock (void far* p)
 {
-	FreeDosMemoryBlock (FP_SEG (p));
+        FreeDosMemoryBlock (FP_SEG (p));
 }
-
 
 bool
 DPMI::RealModeInterrupt (uint iNum, RealModeCall *pRMC)
 {
-	REGS 	r;
-	SREGS s;
-	segread (&s);
-	r.x.eax = 0x300;
-	r.x.ebx = iNum;
-	r.x.ecx = 0;
-	r.x.edi = (uint) pRMC;
-	Interrupt (&r, &s);
-	if ((r.x.cflag & CARRY_FLAG) == 0)
-	{
-		return TRUE;
-	}
-	else
-	{
-		return FALSE;
-	}
+        REGS    r;
+        SREGS s;
+        segread (&s);
+        r.x.eax = 0x300;
+        r.x.ebx = iNum;
+        r.x.ecx = 0;
+        r.x.edi = (uint) pRMC;
+        Interrupt (&r, &s);
+        if ((r.x.cflag & CARRY_FLAG) == 0)
+        {
+                return TRUE;
+        }
+        else
+        {
+                return FALSE;
+        }
 }
-
 
 // Create a protected mode pointer to real memory,
 // given an encoded integer in the format PARAGRAPHS:OFFSET.
@@ -102,20 +92,20 @@ DPMI::RealModeInterrupt (uint iNum, RealModeCall *pRMC)
 void*
 DPMI::RealToProtected (uint realPtr)
 {
-	uint	para, off;
+        uint    para, off;
 
-	para = (realPtr & 0xFFFF0000) >> 16;
-	off = realPtr & 0x0000FFFF;
-	return (void*) (para * 16 + off);
+        para = (realPtr & 0xFFFF0000) >> 16;
+        off = realPtr & 0x0000FFFF;
+        return (void*) (para * 16 + off);
 }
 
-
-// Create a protected mode pointer to real memory, given 
+// Create a protected mode pointer to real memory, given
 // a segment and offset.
 //
 void*
 DPMI::RealToProtected (uint realSeg, uint realOffset)
 {
-	return (void*) ((realSeg << 16) + realOffset);
+        return (void*) ((realSeg << 16) + realOffset);
 }
+#endif // OS_DOS
 

--- a/CODE/TIGRE/DPMI.HPP
+++ b/CODE/TIGRE/DPMI.HPP
@@ -9,60 +9,80 @@
 //
 //----[]-------------------------------------------------------------
 
-
-#ifndef	dpmi_hpp
-#define	dpmi_hpp
-
-#include <i86.h>
+#ifndef dpmi_hpp
+#define dpmi_hpp
 
 #include "types.hpp"
 
+#if defined(OS_DOS)
+#include <i86.h>
 
 struct RealModeCall
 {
-	uint32 edi;
-	uint32 esi;
-	uint32 ebp;
-	uint32 reserved;
-	uint32 ebx;
-	uint32 edx;
-	uint32 ecx;
-	uint32 eax;
-	uint16 flags;
-	uint16 es;
-	uint16 ds;
-	uint16 fs;
-	uint16 gs;
-	uint16 ip;
-	uint16 cs;
-	uint16 sp;
-	uint16 ss;
-	RealModeCall ()
-	{
-		memset (this, 0, sizeof (*this));
-	}
+        uint32 edi;
+        uint32 esi;
+        uint32 ebp;
+        uint32 reserved;
+        uint32 ebx;
+        uint32 edx;
+        uint32 ecx;
+        uint32 eax;
+        uint16 flags;
+        uint16 es;
+        uint16 ds;
+        uint16 fs;
+        uint16 gs;
+        uint16 ip;
+        uint16 cs;
+        uint16 sp;
+        uint16 ss;
+        RealModeCall ()
+        {
+                memset (this, 0, sizeof (*this));
+        }
 };
 
 const uint CARRY_FLAG = 0x1;
-const uint DOS_INT	 = 0x21;
+const uint DOS_INT       = 0x21;
 class DPMI
 {
-	enum MISC { DPMI_INT = 0x31 };
+        enum MISC { DPMI_INT = 0x31 };
 
-	public:
-		DPMI ();
-		virtual ~DPMI ();
-		void 			Interrupt (REGS* r, SREGS* s = NULL);
-		void far* 	AllocateDosMemoryBlock (size_t size, uint16* seg);
-		void 			FreeDosMemoryBlock (uint16 selector);
-		void 			FreeDosMemoryBlock (void far* p);
-		bool 			RealModeInterrupt (uint iNum, RealModeCall *pRMC);
-		void*			RealToProtected (uint realPtr);
-		void*			RealToProtected (uint realSeg, uint realOffset);
+        public:
+                DPMI ();
+                virtual ~DPMI ();
+                void                    Interrupt (REGS* r, SREGS* s = NULL);
+                void far*       AllocateDosMemoryBlock (size_t size, uint16* seg);
+                void                    FreeDosMemoryBlock (uint16 selector);
+                void                    FreeDosMemoryBlock (void far* p);
+                bool                    RealModeInterrupt (uint iNum, RealModeCall *pRMC);
+                void*                   RealToProtected (uint realPtr);
+                void*                   RealToProtected (uint realSeg, uint realOffset);
 };
 
+#else // OS_DOS
+
+struct REGS;
+struct SREGS;
+struct RealModeCall {};
+
+class DPMI
+{
+        public:
+                DPMI () {}
+                virtual ~DPMI () {}
+                void                    Interrupt (REGS*, SREGS* = nullptr) {}
+                void*                   AllocateDosMemoryBlock (size_t, uint16*) { return nullptr; }
+                void                    FreeDosMemoryBlock (uint16) {}
+                void                    FreeDosMemoryBlock (void*) {}
+                bool                    RealModeInterrupt (uint, RealModeCall*) { return false; }
+                void*                   RealToProtected (uint) { return nullptr; }
+                void*                   RealToProtected (uint, uint) { return nullptr; }
+};
+
+#endif // OS_DOS
 
 typedef DPMI* pDPMI;
 
-
 #endif
+

--- a/CODE/TIGRE/MOUSE.CPP
+++ b/CODE/TIGRE/MOUSE.CPP
@@ -15,9 +15,7 @@
 // switch back and forth between to two types, follow the instructions
 // in mousescr.cpp.  
 //
-//----[]-------------------------------------------------------------
-
-
+#if defined(OS_DOS)
 #include <i86.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -414,7 +412,11 @@ Mouse::DrawFence(void)
 void
 Mouse::EraseFence(void)
 {
-	#ifdef OS_MAC
-	// insert Mac code here
-	#endif
+        #ifdef OS_MAC
+        // insert Mac code here
+        #endif
 }
+
+#elif defined(OS_SDL)
+// SDL implementation provided in sdl_mouse.cpp
+#endif

--- a/CODE/TIGRE/OS.CPP
+++ b/CODE/TIGRE/OS.CPP
@@ -24,7 +24,9 @@
 	#error	This is a DOS only module!
 #endif
 
+#ifdef OS_DOS
 #include	<i86.h>
+#endif
 #include	<malloc.h>
 
 

--- a/CODE/TIGRE/OSGRAPH.CPP
+++ b/CODE/TIGRE/OSGRAPH.CPP
@@ -11,6 +11,7 @@
 
 
 #include <stddef.h>
+#if defined(OS_DOS)
 #include <i86.h>
 
 #include "api.hpp"
@@ -665,6 +666,64 @@ CopyPixelsScaledRLE (RCopyPixels* p)
 	}
 		
 	// verify that ExpandRLE() didn't write beyond is output buffer
-	ASSERT (stackCheck == 0xfadefade);
+ASSERT (stackCheck == 0xfadefade);
 
 }
+
+#else // OS_DOS
+
+#include "api.hpp"
+#include "apigraph.hpp"
+#include "apimem.hpp"
+#include "graphmgr.hpp"
+#include "os.hpp"
+#include "osgraph.hpp"
+#include "rle.hpp"
+
+void OS_InitializePlatform() {}
+
+bitmap_t OS_CreateBitMap(coord w, coord h)
+{
+        return AMalloc(w * h);
+}
+
+void OS_DestroyBitMap(bitmap_t bm)
+{
+        if (bm)
+        {
+                AFree(bm);
+        }
+}
+
+uchar* OS_DerefBitMap(bitmap_t bm)
+{
+        return ADerefAs(uchar, bm);
+}
+
+int OS_InitGraphics(GraphicsMgr* pGM, uint mode)
+{
+        (void)pGM;
+        (void)mode;
+        return 0;
+}
+
+void OS_SetPalette(char* gunsArray, uint startGun, uint endGun)
+{
+        (void)gunsArray;
+        (void)startGun;
+        (void)endGun;
+}
+
+void OS_GetPalette(char* gunsArray, uint startGun, uint endGun)
+{
+        (void)gunsArray;
+        (void)startGun;
+        (void)endGun;
+}
+
+void OS_CopyPixels(RCopyPixels* p, bool)
+{
+        (void)p;
+}
+
+#endif // OS_DOS

--- a/CODE/TIGRE/_DEFS386.H
+++ b/CODE/TIGRE/_DEFS386.H
@@ -81,7 +81,9 @@ typedef struct _tag_realptr {
  */
 #if defined( GCPP_WATCOM )
 
+#ifdef OS_DOS
 #include <i86.h>
+#endif
 
 /*
  * Watcom is the one compiler we use right now that actually supports


### PR DESCRIPTION
## Summary
- Wrap `<i86.h>` includes and DOS-only logic with `OS_DOS` guards
- Provide SDL stubs for DOS mouse, DPMI, and graphics modules
- Ensure legacy headers only pull in `<i86.h>` when targeting DOS

## Testing
- `cmake -B build` (fails: could not find SDL2 but stub used)
- `cmake --build build` (fails: precision loss errors in GRAPHMGR.CPP)


------
https://chatgpt.com/codex/tasks/task_e_689c2be20a68832389343c7f122fd38a