### PR TITLE
Add SDL sound stubs and drop DOS-only audio deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,12 +56,13 @@ add_executable(bam ${GAME_SOURCES})
 target_include_directories(bam PRIVATE CODE/SRC CODE/TIGRE)
 target_compile_definitions(bam PRIVATE OS_SDL)
 
-add_library(tigre STATIC
-    CODE/TIGRE/sdl_modex.cpp
-    CODE/TIGRE/sdl_platform.cpp
-    CODE/TIGRE/pentimer.cpp
-    CODE/TIGRE/sdl_mouse.cpp
-    CODE/TIGRE/API.CPP
+  add_library(tigre STATIC
+      CODE/TIGRE/sdl_modex.cpp
+      CODE/TIGRE/sdl_platform.cpp
+      CODE/TIGRE/pentimer.cpp
+      CODE/TIGRE/sdl_mouse.cpp
+      CODE/TIGRE/sdl_sound.cpp
+      CODE/TIGRE/API.CPP
     CODE/TIGRE/GRAPHMGR.CPP
     CODE/TIGRE/SCRIMAGE.CPP
     CODE/TIGRE/PALETTE.CPP
@@ -111,13 +112,6 @@ else()
     target_link_libraries(tigre PUBLIC SDL2::SDL2)
 endif()
 
-# Stub external libraries that are not yet available
-foreach(lib sosdw1cr sosmw1cr netnowr cpfr32 smack)
-    if(NOT TARGET ${lib})
-        add_library(${lib} INTERFACE)
-    endif()
-endforeach()
-
-target_link_libraries(bam PRIVATE SDL2::SDL2 tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)
+target_link_libraries(bam PRIVATE SDL2::SDL2 tigre)
 
 add_subdirectory(tests)

--- a/CODE/TIGRE/SOUNDMGR.CPP
+++ b/CODE/TIGRE/SOUNDMGR.CPP
@@ -1,3 +1,5 @@
+#ifdef OS_DOS
+
 #include "../compat.h"
 //
 // SOUNDMGR.CPP
@@ -2626,9 +2628,8 @@ TMusic::Fade(uint16 direction, uint32 currentStep, uint32 totalSteps)
 	}
 	else
 	{
-		return FALSE;
-	}
+        return FALSE;
+        }
 }
 
-
-
+#endif

--- a/CODE/TIGRE/sdl_sound.cpp
+++ b/CODE/TIGRE/sdl_sound.cpp
@@ -1,0 +1,58 @@
+#include "sdl_sound.hpp"
+
+SoundMgr* pSoundMgr = nullptr;
+
+SoundMgr::SoundMgr() : hDigiDriverHandle(-1) {
+    pSoundMgr = this;
+}
+
+SoundMgr::~SoundMgr() {
+    pSoundMgr = nullptr;
+}
+
+void SoundMgr::Init(char*) {}
+void SoundMgr::Cycle() {}
+void SoundMgr::Pause() {}
+void SoundMgr::Resume() {}
+void SoundMgr::SetMasterDigiVolume(int16) {}
+int16 SoundMgr::GetMasterDigiVolume() { return 0; }
+void SoundMgr::SetMasterMidiVolume(int16) {}
+int16 SoundMgr::GetMasterMidiVolume() { return 0; }
+void SoundMgr::ShutDown() {}
+bool SoundMgr::Save(uint16, FILE*) { return false; }
+uint16 SoundMgr::NumberDigiPlaying() { return 0; }
+uint16 SoundMgr::NumberMidiPlaying() { return 0; }
+grip SoundMgr::OldestDigiPlaying() { return 0; }
+grip SoundMgr::NextOldestDigiPlaying() { return 0; }
+grip SoundMgr::OldestMidiPlaying() { return 0; }
+bool SoundMgr::Fade(uint16, uint32, uint32) { return false; }
+void SoundMgr::AutoFade(uint16, uint32, uint32, grip) {}
+void SoundMgr::SwapDigiLeftAndRight(bool) {}
+short SoundMgr::GetPanPosition(int panPos) { return static_cast<short>(panPos); }
+
+TSound::TSound() {}
+TSound::~TSound() {}
+void TSound::Play(int, int16, int, grip, int16, bool) {}
+void TSound::SetVolume(int16, int, bool) {}
+void TSound::Stop() {}
+int TSound::IsPlaying() { return 0; }
+void TSound::Pause() {}
+void TSound::Resume() {}
+bool TSound::Fade(uint16, uint32, uint32) { return false; }
+void TSound::SetPanPosition(int) {}
+TStreamBase* TSound::GetStreamer() { return nullptr; }
+
+TMusic::TMusic() {}
+TMusic::~TMusic() {}
+void TMusic::Play(uint16, int16, grip) {}
+void TMusic::Stop() {}
+int TMusic::IsPlaying() { return 0; }
+void TMusic::Pause() {}
+void TMusic::Resume() {}
+void TMusic::SetVolume(int16, int, bool) {}
+bool TMusic::Fade(uint16, uint32, uint32) { return false; }
+
+void ShutDownSoundMgr() {}
+
+extern "C" unsigned char SmackSoundUseSOS3(unsigned short, unsigned long) { return 0; }
+

--- a/CODE/TIGRE/sdl_sound.hpp
+++ b/CODE/TIGRE/sdl_sound.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "types.hpp"
+#include <stdio.h>
+
+class TStreamBase;
+
+class TSound {
+public:
+    TSound();
+    ~TSound();
+
+    void Play(int sndNum, int16 sVolume = 0, int panPos = 0,
+              grip callBack = 0, int16 loopCnt = 1, bool streamIt = false);
+    void SetVolume(int16 sVolume, int panPos = 0, bool updateMax = true);
+    void Stop();
+    int IsPlaying();
+    void Pause();
+    void Resume();
+    bool Fade(uint16 direction, uint32 currentStep, uint32 totalSteps);
+    void SetPanPosition(int panPos);
+    TStreamBase* GetStreamer();
+};
+
+class TMusic {
+public:
+    TMusic();
+    ~TMusic();
+
+    void Play(uint16 sngNum, int16 mVolume = 0, grip callBack = 0);
+    void Stop();
+    int IsPlaying();
+    void Pause();
+    void Resume();
+    void SetVolume(int16 sVolume, int panPos = 0, bool updateMax = true);
+    bool Fade(uint16 direction, uint32 currentStep, uint32 totalSteps);
+};
+
+class SoundMgr {
+public:
+    SoundMgr();
+    ~SoundMgr();
+
+    void Init(char *configFileName = (char*)"sound.cfg");
+    void Cycle();
+
+    void Pause();
+    void Resume();
+
+    void SetMasterDigiVolume(int16 volume);
+    int16 GetMasterDigiVolume();
+    void SetMasterMidiVolume(int16 volume);
+    int16 GetMasterMidiVolume();
+
+    void ShutDown();
+
+    bool Save(uint16 state, FILE *fp = nullptr);
+
+    uint16 NumberDigiPlaying();
+    uint16 NumberMidiPlaying();
+
+    grip OldestDigiPlaying();
+    grip NextOldestDigiPlaying();
+    grip OldestMidiPlaying();
+
+    bool Fade(uint16 direction, uint32 currentStep, uint32 totalSteps);
+    void AutoFade(uint16 direction, uint32 totalSteps, uint32 stepDelay, grip callBack = 0);
+
+    void SwapDigiLeftAndRight(bool swapThem);
+    short GetPanPosition(int panPos);
+
+    int hDigiDriverHandle;
+};
+
+extern SoundMgr* pSoundMgr;
+void ShutDownSoundMgr();
+
+extern "C" unsigned char SmackSoundUseSOS3(unsigned short, unsigned long);
+

--- a/CODE/TIGRE/soundmgr.hpp
+++ b/CODE/TIGRE/soundmgr.hpp
@@ -1,1 +1,5 @@
+#ifdef OS_DOS
 #include "SOUNDMGR.HPP"
+#else
+#include "sdl_sound.hpp"
+#endif


### PR DESCRIPTION
## Summary
- stub out SoundMgr, TSound and TMusic for SDL builds
- compile legacy SoundMgr only on OS_DOS
- remove unused SOS libraries from build

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: cast from void*/char* loses precision in GRAPHMGR.CPP)*

------
https://chatgpt.com/codex/tasks/task_e_689c329148c08323a066843986d63f5c