### PR TITLE
Stub keyboard and tick functions

### DIFF
--- a/CODE/TIGRE/APIEVT.HPP
+++ b/CODE/TIGRE/APIEVT.HPP
@@ -9,30 +9,28 @@
 //
 //----[]-------------------------------------------------------------
 
-
-#ifndef	apievt_hpp
-#define	apievt_hpp
-
+#ifndef apievt_hpp
+#define apievt_hpp
 
 #include "eventmgr.hpp"
 #include "tigre.hpp"
 #include "types.hpp"
 
+bool            AEvtMgr();
 
-bool		AEvtMgr();
-
-bool		APostEvent(evt_t type, int32 value, bool turnInterruptsOff = TRUE);
-bool		APostNotice(notice_t type, grip gDest = 0, void* param = NULL, grip gSource = 0);
-bool		ASendNotice(notice_t type, grip gDest = 0, grip gSource = 0, void* param = NULL);
-uint		AFlushEvents(evt_t mask = E_KEY_DOWN | E_KEY_UP | E_MOUSE_DOWN | E_MOUSE_UP);
-uint		AFlushNotices(grip gDest);
-void		APublishNext();
-char		AScanToASCII(Event e);
-uchar*	AGetBiosKey();
-void		AQueueUpdate();
-uint16	AGetEventMods();
-void		ASetKeyboardVector(bool setup = TRUE);
-void		AAutoUpdateTicks(bool updateIt);
-
+bool            APostEvent(evt_t type, int32 value, bool turnInterruptsOff = TRUE);
+bool            APostNotice(notice_t type, grip gDest = 0, void* param = NULL, grip gSource = 0);
+bool            ASendNotice(notice_t type, grip gDest = 0, grip gSource = 0, void* param = NULL);
+uint            AFlushEvents(evt_t mask = E_KEY_DOWN | E_KEY_UP | E_MOUSE_DOWN | E_MOUSE_UP);
+uint            AFlushNotices(grip gDest);
+void            APublishNext();
+char            AScanToASCII(Event e);
+uchar*          AGetBiosKey();
+void            AQueueUpdate();
+uint16          AGetEventMods();
+void            ASetKeyboardVector(bool setup = TRUE);
+ticks_t         AGetTicks();
+void            AAutoUpdateTicks(bool updateIt);
 
 #endif
+

--- a/CODE/TIGRE/OS_STUB.CPP
+++ b/CODE/TIGRE/OS_STUB.CPP
@@ -3,6 +3,8 @@
 #include "apigraph.hpp"
 #include "types.hpp"
 
+#include <SDL2/SDL.h>
+
 extern "C" void _Panic(char* msg, char* fileName, int lineNum)
 {
     (void)msg;
@@ -36,4 +38,12 @@ uint16 AGetEventMods()
     return pEventMgr ? pEventMgr->GetModifiers() : 0;
 }
 
-void ASetKeyboardVector(bool) {}
+ticks_t AGetTicks()
+{
+    return SDL_GetTicks();
+}
+
+void ASetKeyboardVector(bool setup)
+{
+    (void)setup;
+}


### PR DESCRIPTION
## Summary
- add SDL-based tick retrieval and keyboard vector stub
- declare AGetTicks in public event API

## Testing
- `cmake --build build` *(fails: cast from `char*` to `int` loses precision in GRAPHMGR.CPP)*

------
https://chatgpt.com/codex/tasks/task_e_689c97691e088323b67b46ed1ab14be3