### PR TITLE
Simplify test_init library dependencies

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(test_init test_init.cpp)
 
 target_include_directories(test_init PRIVATE ${PROJECT_SOURCE_DIR}/CODE/SRC ${PROJECT_SOURCE_DIR}/CODE/TIGRE)
 
-target_link_libraries(test_init PRIVATE SDL2::SDL2 tigre sosdw1cr sosmw1cr netnowr cpfr32 smack)
+target_link_libraries(test_init PRIVATE SDL2::SDL2 tigre)
 
 target_compile_definitions(test_init PRIVATE TEST_ASSET_DIR="${PROJECT_SOURCE_DIR}")
 target_compile_definitions(test_init PRIVATE OS_SDL)


### PR DESCRIPTION
## Summary
- remove unused libraries from test_init

## Testing
- `cmake -S . -B build`
- `cmake --build build --target test_init` *(fails: Error 2)*

------
https://chatgpt.com/codex/tasks/task_e_689cb2dbfdb0832382d783aaeff28936