### PR TITLE
Guard SDL timer event with global EventMgr pointer

### DIFF
--- a/CODE/TIGRE/sdl_eventmgr.cpp
+++ b/CODE/TIGRE/sdl_eventmgr.cpp
@@ -197,7 +197,8 @@ void EventMgr::HandleSDLEvent(const SDL_Event& ev)
             PostEventXY(E_MOUSE_UP, ev.button.button, gMouseX, gMouseY);
             break;
         case SDL_USEREVENT:
-            clock.Cycle();
+            if(pEventMgr)
+                pEventMgr->clock.Cycle();
             break;
         default:
             break;


### PR DESCRIPTION
## Summary
- call `pEventMgr->clock.Cycle()` for SDL timer events
- guard against null `pEventMgr` before ticking the clock

## Testing
- `cmake -S . -B build` *(fails: could not find SDL2)*
- `cmake --build build` *(fails: build error)*

------
https://chatgpt.com/codex/tasks/task_e_689cba7e65708323a80e5a228b10d025