### PR TITLE
Add SDL cleanup and timer management

### DIFF
--- a/CODE/TIGRE/EVENTMGR.HPP
+++ b/CODE/TIGRE/EVENTMGR.HPP
@@ -24,6 +24,9 @@
 #include "keybrd.hpp"
 
 struct SDL_Event;
+#ifdef OS_SDL
+#include <SDL2/SDL.h>
+#endif
 
 
 
@@ -54,6 +57,9 @@ class EventMgr : public Manager, public Object
 		uint			nqSize;
 		bool			inInterrupt;
 		uchar*		real_ptr_bios_key_status;
+#ifdef OS_SDL
+		SDL_TimerID		timerID;
+#endif
 
 		EventMgr(uint nsize = MESSAGE_Q_SIZE, uint esize = MESSAGE_Q_SIZE);
 		virtual		~EventMgr();

--- a/CODE/TIGRE/MODEX.HPP
+++ b/CODE/TIGRE/MODEX.HPP
@@ -34,6 +34,7 @@ extern "C"
 	void	XModeFlipPage(void);
 	void	FillScreen(int penNum);
 	void	SyncWithVBL();
+	void	DestroyXMode(void);
 }
 
 #endif

--- a/CODE/TIGRE/OS_STUB.CPP
+++ b/CODE/TIGRE/OS_STUB.CPP
@@ -5,6 +5,8 @@
 
 #include <SDL2/SDL.h>
 
+extern "C" void DestroyXMode(void);
+
 extern "C" void _Panic(char* msg, char* fileName, int lineNum)
 {
     (void)msg;
@@ -15,6 +17,8 @@ extern "C" void _Panic(char* msg, char* fileName, int lineNum)
 void OS_ShutDownVideo(int origMode)
 {
     (void)origMode;
+    DestroyXMode();
+    SDL_Quit();
 }
 
 void OS_InitMem() {}

--- a/CODE/TIGRE/sdl_eventmgr.cpp
+++ b/CODE/TIGRE/sdl_eventmgr.cpp
@@ -138,7 +138,7 @@ static uint16 SDLModToModifiers(SDL_Keymod m)
 EventMgr::EventMgr(uint nsize, uint esize)
     : feedEvents(true), pQEvents(nullptr), iEHead(0), iETail(0), eqSize(esize),
       pQNotices(nullptr), iNHead(0), iNTail(0), nqSize(nsize), inInterrupt(false),
-      real_ptr_bios_key_status(&g_bios_key_status), autoUpdateTicks(true)
+      real_ptr_bios_key_status(&g_bios_key_status), autoUpdateTicks(true), timerID(0)
 {
     pQEvents = new Message[eqSize];
     pQNotices = new Message[nqSize];
@@ -146,11 +146,13 @@ EventMgr::EventMgr(uint nsize, uint esize)
     for(uint i=0;i<nqSize;i++) InitNotice(&pQNotices[i]);
     memset(scanKeys,0,sizeof(scanKeys));
     if(!pEventMgr) pEventMgr = this;
-    SDL_AddTimer(1000 / TICKS_PER_SEC, TimerCallback, nullptr);
+    timerID = SDL_AddTimer(1000 / TICKS_PER_SEC, TimerCallback, nullptr);
 }
 
 EventMgr::~EventMgr()
 {
+    if(timerID)
+        SDL_RemoveTimer(timerID);
     delete [] pQEvents;
     delete [] pQNotices;
     if(pEventMgr==this) pEventMgr = nullptr;

--- a/CODE/TIGRE/sdl_modex.cpp
+++ b/CODE/TIGRE/sdl_modex.cpp
@@ -95,3 +95,24 @@ void ARBlit(uint driver, uchar* pData, coord x, coord y,
     }
 }
 
+void DestroyXMode(void)
+{
+    if(gTexture)
+    {
+        SDL_DestroyTexture(gTexture);
+        gTexture = nullptr;
+    }
+    if(gRenderer)
+    {
+        SDL_DestroyRenderer(gRenderer);
+        gRenderer = nullptr;
+    }
+    if(gWindow)
+    {
+        SDL_DestroyWindow(gWindow);
+        gWindow = nullptr;
+    }
+    gPages.clear();
+    pVGAMem = pVGAMemPage0 = pVGAMemPage1 = nullptr;
+}
+

--- a/stubs/SDL2/SDL.h
+++ b/stubs/SDL2/SDL.h
@@ -34,12 +34,20 @@ static inline int SDL_UpdateTexture(SDL_Texture*, const void*, const void*, int)
 static inline int SDL_RenderClear(SDL_Renderer*) { return 0; }
 static inline int SDL_RenderCopy(SDL_Renderer*, SDL_Texture*, const void*, const void*) { return 0; }
 static inline void SDL_RenderPresent(SDL_Renderer*) {}
+static inline void SDL_DestroyTexture(SDL_Texture*) {}
+static inline void SDL_DestroyRenderer(SDL_Renderer*) {}
+static inline void SDL_DestroyWindow(SDL_Window*) {}
 static inline int SDL_PollEvent(SDL_Event*) { return 0; }
 static inline void SDL_Delay(Uint32) {}
 static inline Uint32 SDL_GetTicks(void) { return 0; }
 static inline Uint32 SDL_GetMouseState(int* x, int* y) { if(x) *x = 0; if(y) *y = 0; return 0; }
 static inline int SDL_ShowCursor(int toggle) { return toggle; }
 static inline int SDL_WarpMouseGlobal(int x, int y) { (void)x; (void)y; return 0; }
+
+typedef void* SDL_TimerID;
+typedef Uint32 (*SDL_TimerCallback)(Uint32 interval, void* param);
+static inline SDL_TimerID SDL_AddTimer(Uint32, SDL_TimerCallback, void*) { return 0; }
+static inline int SDL_RemoveTimer(SDL_TimerID) { return SDL_TRUE; }
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- Destroy SDL renderer, texture and window when shutting down video
- Expose `DestroyXMode` and call it from `OS_ShutDownVideo`
- Track SDL timer ID in `EventMgr` and remove timer on destruction
- Expand SDL stub header with timer and destroy helpers

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: cast from ‘void*’ to ‘grip’ loses precision, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689cbcd02954832390a3e9614cdd69c8