### PR TITLE
Stub out SoundMgr::Save

### DIFF
--- a/CODE/TIGRE/sdl_sound.cpp
+++ b/CODE/TIGRE/sdl_sound.cpp
@@ -18,8 +18,8 @@ void SoundMgr::SetMasterDigiVolume(int16) {}
 int16 SoundMgr::GetMasterDigiVolume() { return 0; }
 void SoundMgr::SetMasterMidiVolume(int16) {}
 int16 SoundMgr::GetMasterMidiVolume() { return 0; }
-void SoundMgr::ShutDown() {}
-bool SoundMgr::Save(uint16, FILE*) { return false; }
+void SoundMgr::ShutDown() { /* stub: nothing to shut down */ }
+bool SoundMgr::Save(uint16, FILE*) { return true; /* stub: pretend success */ }
 uint16 SoundMgr::NumberDigiPlaying() { return 0; }
 uint16 SoundMgr::NumberMidiPlaying() { return 0; }
 grip SoundMgr::OldestDigiPlaying() { return 0; }
@@ -52,4 +52,4 @@ void TMusic::Resume() {}
 void TMusic::SetVolume(int16, int, bool) {}
 bool TMusic::Fade(uint16, uint32, uint32) { return false; }
 
-void ShutDownSoundMgr() {}
+void ShutDownSoundMgr() { /* stub */ }


### PR DESCRIPTION
## Summary
- Mark `SoundMgr::Save` as a stub that always succeeds
- Annotate `ShutDown` routines as no-op stubs

## Testing
- `cmake -S . -B build` *(fails: SDL2 not found)*
- `cmake --build build` *(fails: cast from `void*` to `grip` loses precision)*
- `ctest --output-on-failure` *(not run: test executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_689cc0aa49b08323ada6e09b6dee6651