### PR TITLE
Expose SDL window for mouse warping

### DIFF
--- a/CODE/TIGRE/sdl_modex.cpp
+++ b/CODE/TIGRE/sdl_modex.cpp
@@ -2,6 +2,7 @@
 #include "modex.hpp"
 #include "apigraph.hpp"
 #include "types.hpp"
+#include "sdl_modex.hpp"
 #include <SDL2/SDL.h>
 #include <vector>
 #include <cstring>
@@ -36,6 +37,12 @@ static void ensureInit()
         curDrawPage = 0;
         pVGAMem = pVGAMemPage0;
     }
+}
+
+SDL_Window* GetSDLWindow()
+{
+    ensureInit();
+    return gWindow;
 }
 
 void SetXMode(void)

--- a/CODE/TIGRE/sdl_modex.hpp
+++ b/CODE/TIGRE/sdl_modex.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+struct SDL_Window;
+
+SDL_Window* GetSDLWindow();
+

--- a/CODE/TIGRE/sdl_mouse.cpp
+++ b/CODE/TIGRE/sdl_mouse.cpp
@@ -2,6 +2,7 @@
 #include "mouse.hpp"
 #include "tigre.hpp"
 #include <SDL2/SDL.h>
+#include "sdl_modex.hpp"
 
 Mouse* pMouse = nullptr;
 
@@ -26,6 +27,7 @@ Mouse::~Mouse()
 
 void Mouse::Init(coord x1, coord y1, coord x2, coord y2)
 {
+    GetSDLWindow();
     screenLimits.Set(x1,y1,x2,y2);
     rClickDrag.Set(-1,-1,-1,-1);
     fDragMode = false;
@@ -147,13 +149,15 @@ public:
     void SetX(coord setX) override
     {
         x = setX;
-        SDL_WarpMouseGlobal(x, y);
+        if(SDL_Window* window = GetSDLWindow())
+            SDL_WarpMouseInWindow(window, x, y);
     }
 
     void SetY(coord setY) override
     {
         y = setY;
-        SDL_WarpMouseGlobal(x, y);
+        if(SDL_Window* window = GetSDLWindow())
+            SDL_WarpMouseInWindow(window, x, y);
     }
 
     int GetCel() override { return cel; }

--- a/stubs/SDL2/SDL.h
+++ b/stubs/SDL2/SDL.h
@@ -44,6 +44,7 @@ static inline Uint32 SDL_GetTicks(void) { return 0; }
 static inline Uint32 SDL_GetMouseState(int* x, int* y) { if(x) *x = 0; if(y) *y = 0; return 0; }
 static inline int SDL_ShowCursor(int toggle) { return toggle; }
 static inline int SDL_WarpMouseGlobal(int x, int y) { (void)x; (void)y; return 0; }
+static inline void SDL_WarpMouseInWindow(SDL_Window*, int, int) {}
 
 typedef void* SDL_TimerID;
 typedef Uint32 (*SDL_TimerCallback)(Uint32 interval, void* param);


### PR DESCRIPTION
## Summary
- Add `GetSDLWindow` accessor in SDL mode X backend
- Use `SDL_WarpMouseInWindow` in SDL mouse handling
- Provide stub for `SDL_WarpMouseInWindow`

## Testing
- `cmake -S . -B build`
- `cmake --build build` *(fails: cast from void* to grip loses precision in CODE/TIGRE/GRAPHMGR.CPP)*

------
https://chatgpt.com/codex/tasks/task_e_689cc1aab39c8323ae55ba18baadd751